### PR TITLE
added computation of IDs at initialization

### DIFF
--- a/lib/python/brand/node.py
+++ b/lib/python/brand/node.py
@@ -61,6 +61,9 @@ class BRANDNode():
         self.producer_gid_hex = uuid.uuid4().hex
         
         self._cursor = {}
+        # Potentially, get latest ID for each input stream
+        input_stream_names = [self.parameters['input_streams'][key]['name'] for key in self.parameters['input_streams'].keys()]
+        self.get_latest_id_per_stream(input_stream_names)
         
         # Add shutdown flag for graceful termination
         self._shutdown_requested = False
@@ -208,6 +211,17 @@ class BRANDNode():
 
         for key,value in node_parameters[-1].items():
             self.parameters[key] = value
+    
+    def get_latest_id_per_stream(self, streams:list[str]):
+        """
+        Get the latest ID for each stream in the list
+        """
+        for stream in streams:
+            try:
+                self._cursor[stream] = self.r.xinfo_stream(stream)['last-generated-id']
+            except Exception as e:
+                self.logger.warning(f"Error getting latest ID for stream {stream}: {e}")
+                self._cursor[stream] = "$"
 
     def run(self):
 


### PR DESCRIPTION
This is needed to be able to do non-blocking calls further down the line. It basically just computes the last entry ID at initialization and then when reading it can use those entries as a reference point.
This modification was key to allow reading from multiple streams at the same time: hadn't realized that when you do an xread non blocking with multiple streams, the method will just return once it can read messages from at least one stream. So the cursor for the other streams would never get updated. 
Tried it on the other nodes and it works well.